### PR TITLE
feat: add support for linking storage with different data source types

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ End-to-end testing is not conducted on these modules, as they are individual com
 - Supports multiple data export rules to streamline data management.
 - Ability to generate a user assigned identity or bring your own if specified.
 - Enables linking with an automation account.
+- Supports linking multiple storage accounts with different data source types.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | [azurerm_log_analytics_data_export_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_data_export_rule) | resource |
 | [azurerm_user_assigned_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_log_analytics_linked_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_linked_service) | resource |
+| [azurerm_log_analytics_linked_storage_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_linked_storage_account) | resource |
 
 ## Inputs
 

--- a/examples/linked-storage/README.md
+++ b/examples/linked-storage/README.md
@@ -1,0 +1,24 @@
+# Linked Storage
+
+This deploys storage linked to the log analytics workspace.
+
+## Types
+
+```hcl
+law = object({
+  name            = string
+  location        = string
+  resourcegroup   = string
+  read_access_id  = optional(string)
+  write_access_id = optional(string)
+  linked_storage  = optional(map(object({
+    data_source_type    = string
+    resourcegroup       = optional(string)
+    storage_account_ids = list(string)
+  })))
+})
+```
+
+## Notes
+
+For data source type alerts, only one storage account can be linked.

--- a/examples/linked-storage/main.tf
+++ b/examples/linked-storage/main.tf
@@ -1,0 +1,62 @@
+module "naming" {
+  source  = "cloudnationhq/naming/azure"
+  version = "~> 0.1"
+
+  suffix = ["demo", "dev"]
+}
+
+module "rg" {
+  source  = "cloudnationhq/rg/azure"
+  version = "~> 0.1"
+
+  groups = {
+    demo = {
+      name   = module.naming.resource_group.name
+      region = "westeurope"
+    }
+  }
+}
+
+module "storage1" {
+  source  = "cloudnationhq/sa/azure"
+  version = "~> 0.1"
+
+  storage = {
+    name          = "stdemodev1"
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+  }
+}
+
+module "storage2" {
+  source  = "cloudnationhq/sa/azure"
+  version = "~> 0.1"
+
+  storage = {
+    name          = "stdemodev2"
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+  }
+}
+
+module "analytics" {
+  source  = "cloudnationhq/law/azure"
+  version = "~> 0.1"
+
+  law = {
+    name          = module.naming.log_analytics_workspace.name_unique
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+
+    linked_storage = {
+      customlogs = {
+        data_source_type    = "CustomLogs"
+        storage_account_ids = [module.storage1.account.id]
+      },
+      alerts = {
+        data_source_type    = "Alerts"
+        storage_account_ids = [module.storage2.account.id]
+      }
+    }
+  }
+}

--- a/examples/linked-storage/terraform.tf
+++ b/examples/linked-storage/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.61"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}


### PR DESCRIPTION
## Description

This PR links optionally multiple storage account with the ability to specify different data source types

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #59
