### PR TITLE
feat: add support for tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | [azurerm_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [azurerm_log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_log_analytics_solution](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_solution) | resource |
+| [azurerm_log_analytics_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace_table) | resource |
 | [azurerm_log_analytics_data_export_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_data_export_rule) | resource |
 | [azurerm_user_assigned_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_log_analytics_linked_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_linked_service) | resource |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | [azurerm_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [azurerm_log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_log_analytics_solution](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_solution) | resource |
-| [azurerm_log_analytics_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace_table) | resource |
+| [azurerm_log_analytics_workspace_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace_table) | resource |
 | [azurerm_log_analytics_data_export_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_data_export_rule) | resource |
 | [azurerm_user_assigned_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_log_analytics_linked_service](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_linked_service) | resource |

--- a/examples/tables/README.md
+++ b/examples/tables/README.md
@@ -1,0 +1,24 @@
+# Solutions
+
+This deploys tables within a log analytic workspace.
+
+This resource does not create or destroy tables. This resource is used to update attributes (currently only retention_in_days) of the tables created when a Log Analytics Workspace is created.
+Deleting an azurerm_log_analytics_workspace_table resource will not delete the table. Instead, the table's retention_in_days field will be set to the value of azurerm_log_analytics_workspace retention_in_days
+
+## Types
+
+```hcl
+workspace = object({
+  name           = string
+  location       = string
+  resource_group = string
+  tables      = optional(map(object({
+    plan                    = string
+    retention_in_days       = number
+    total_retention_in_days = number
+  })))
+})
+```
+
+## Notes
+The retention_in_days cannot be specified when plan is Basic because the retention is fixed at eight days.

--- a/examples/tables/main.tf
+++ b/examples/tables/main.tf
@@ -1,0 +1,56 @@
+module "naming" {
+  source  = "cloudnationhq/naming/azure"
+  version = "~> 0.1"
+
+  suffix = ["law", "complete"]
+}
+
+module "rg" {
+  source  = "cloudnationhq/rg/azure"
+  version = "~> 0.1"
+
+  groups = {
+    demo = {
+      name   = module.naming.resource_group.name
+      region = "westeurope"
+    }
+  }
+}
+
+module "storage" {
+  source  = "cloudnationhq/sa/azure"
+  version = "~> 0.1"
+
+  storage = {
+    name          = module.naming.storage_account.name_unique
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+  }
+}
+
+module "analytics" {
+  source  = "cloudnationhq/law/azure"
+  version = "~> 1.0"
+
+  workspace = {
+    name           = module.naming.log_analytics_workspace.name_unique
+    location       = module.rg.groups.demo.location
+    resource_group = module.rg.groups.demo.name
+
+    tables = {
+      InsightsMetrics = {
+        plan                    = "Analytics"
+        retention_in_days       = 40
+        total_retention_in_days = 50
+      }
+      Alert = {
+        plan                    = "Analytics"
+        retention_in_days       = 30
+        total_retention_in_days = 60
+      }
+      ContainerLogV2 = {
+        plan = "Basic"
+      }
+    }
+  }
+}

--- a/examples/tables/terraform.tf
+++ b/examples/tables/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.61"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/locals.tf
+++ b/locals.tf
@@ -11,4 +11,11 @@ locals {
       tags           = try(solution.tags, var.tags, null)
     }
   }
+  tables = {
+    for table_key, table in try(var.workspace.tables, {}) : table_key => {
+      plan                    = try(table.plan, "Analytics")
+      retention_in_days       = table.plan == "Basic" ? null : try(table.retention_in_days, 30)
+      total_retention_in_days = try(table.total_retention_in_days, 30)
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,18 @@ resource "azurerm_log_analytics_solution" "solutions" {
   }
 }
 
+# tables
+resource "azurerm_log_analytics_workspace_table" "tables" {
+  for_each = local.tables
+
+  workspace_id = azurerm_log_analytics_workspace.ws.id
+  name         = each.key
+  plan         = each.value.plan
+
+  retention_in_days       = each.value.plan == "Basic" ? null : each.value.retention_in_days
+  total_retention_in_days = each.value.total_retention_in_days
+}
+
 # data export rules
 resource "azurerm_log_analytics_data_export_rule" "rule" {
   for_each = length(lookup(var.workspace, "export_rules", {})) > 0 ? lookup(var.workspace, "export_rules", {}) : {}


### PR DESCRIPTION
## Description

The code changes add support for creating log analytics workspace tables in the Terraform configuration. This allows users to define tables within a log analytics workspace and specify properties such as plan, retention in days, and total retention in days.

Adding functionality for tables within log analytics workspace. (Issue #31)

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `log_analytics_workspace ` - support for the `tables` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #31 
