### PR TITLE
fix: update workspace id property in linked storage account resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "azurerm_log_analytics_linked_storage_account" "link" {
   )
 
 
-  data_source_type      = each.value.data_source_type
-  workspace_resource_id = azurerm_log_analytics_workspace.ws.id
-  storage_account_ids   = each.value.storage_account_ids
+  data_source_type    = each.value.data_source_type
+  workspace_id        = azurerm_log_analytics_workspace.ws.id
+  storage_account_ids = each.value.storage_account_ids
 }


### PR DESCRIPTION
## Description

azurerm_log_analytics_linked_storage_account: missing optional property workspace_id in root (resource)

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything) 

* azurerm_log_analytics_linked_storage_account: missing optional property workspace_id in root (resource)


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes [#100](https://github.com/CloudNationHQ/terraform-azure-law/issues/100)
